### PR TITLE
[VEGA-1063] Adding new global cache key

### DIFF
--- a/docs/resources/mte_config.md
+++ b/docs/resources/mte_config.md
@@ -22,7 +22,20 @@ resource "altitude_mte_config" "config" {
         enable_ssl           = true
         preserve_path_prefix = true
         shield_location      = "London"
-        cache_max_age        = 360
+      }
+    ]
+    cache = [
+      {
+        path_rules = {
+          any_match = [
+            "/foo**"
+          ]
+        }
+        keys = {
+          headers = ["X-Header"]
+          cookies = ["X-Cookie"]
+        }
+        ttl_seconds = 100
       }
     ]
   }
@@ -48,6 +61,7 @@ Required:
 Optional:
 
 - `basic_auth` (Attributes) (see [below for nested schema](#nestedatt--config--basic_auth))
+- `cache` (Attributes List) A list of settings designed to manipulate your cache without requiring you to set response headers. (see [below for nested schema](#nestedatt--config--cache))
 
 <a id="nestedatt--config--routes"></a>
 ### Nested Schema for `config.routes`
@@ -62,18 +76,7 @@ Required:
 Optional:
 
 - `append_path_prefix` (String) A string which will be appended to the start of the path sent to the host.
-- `cache_key` (Attributes) An object specifying header and cookie names which should be added to the cache key. The result of this would lead to separate cache hits for requests with different values of the header or cookie. (see [below for nested schema](#nestedatt--config--routes--cache_key))
-- `cache_max_age` (Number) An int that will be used to specify the time that the response of the route should be stored in the cache, in seconds.
 - `shield_location` (String) This describes the location which all requests will be forwarded to before reaching the origin of this route.
-
-<a id="nestedatt--config--routes--cache_key"></a>
-### Nested Schema for `config.routes.cache_key`
-
-Required:
-
-- `cookies` (List of String) A list of cookie names which the cache key will differeniate upon the values of these cookies.
-- `headers` (List of String) A list of header names of which the cache key will differeniate upon the values of these headers.
-
 
 
 <a id="nestedatt--config--basic_auth"></a>
@@ -83,3 +86,30 @@ Required:
 
 - `password` (String) The password which clients will enter to authorize viewing this environment.
 - `username` (String) The username which clients will enter to authorize viewing this environment.
+
+
+<a id="nestedatt--config--cache"></a>
+### Nested Schema for `config.cache`
+
+Optional:
+
+- `keys` (Attributes) An object specifying header and cookie names which should be added to the cache key. The result of this would lead to separate cache hits for requests with different values of the header or cookie. One of this (see [below for nested schema](#nestedatt--config--cache--keys))
+- `path_rules` (Attributes) A set of glob rules which identify when the cache settings should be activated. (see [below for nested schema](#nestedatt--config--cache--path_rules))
+- `ttl_seconds` (Number) An integer that will be used to specify the time that the response of the route should be stored in the cache, in seconds.
+
+<a id="nestedatt--config--cache--keys"></a>
+### Nested Schema for `config.cache.keys`
+
+Required:
+
+- `cookies` (List of String) A list of cookie names which the cache key will differeniate upon the values of these cookies.
+- `headers` (List of String) A list of header names of which the cache key will differeniate upon the values of these headers.
+
+
+<a id="nestedatt--config--cache--path_rules"></a>
+### Nested Schema for `config.cache.path_rules`
+
+Required:
+
+- `any_match` (List of String) A list of glob paths where one of the list needs to match for the cache settings to be activated for a path. If both this field and `none_match` are specified, both need to be successful for the path to match.
+- `none_match` (List of String) A list of glob paths where all of the list needs to not match the path for the cache settings to be activated. If both this field and `any_match` are specified, both need to be successful for the path to match.

--- a/examples/resources/altitude_mte_config/resource.tf
+++ b/examples/resources/altitude_mte_config/resource.tf
@@ -7,7 +7,20 @@ resource "altitude_mte_config" "config" {
         enable_ssl           = true
         preserve_path_prefix = true
         shield_location      = "London"
-        cache_max_age        = 360
+      }
+    ]
+    cache = [
+      {
+        path_rules = {
+          any_match = [
+            "/foo**"
+          ]
+        }
+        keys = {
+          headers = ["X-Header"]
+          cookies = ["X-Cookie"]
+        }
+        ttl_seconds = 100
       }
     ]
   }

--- a/internal/provider/client/mte_config_create.go
+++ b/internal/provider/client/mte_config_create.go
@@ -26,7 +26,7 @@ func (c *Client) CreateMTEConfig(
 
 	httpRes, err := c.initiateRequest(
 		http.MethodPost,
-		fmt.Sprintf("/v1/environment/%s/mte/altitude-config", input.EnvironmentId),
+		fmt.Sprintf("/v2/environment/%s/mte/altitude-config", input.EnvironmentId),
 		bytes.NewBuffer(jsonBody))
 
 	if err != nil {

--- a/internal/provider/client/mte_config_delete.go
+++ b/internal/provider/client/mte_config_delete.go
@@ -15,7 +15,7 @@ func (c *Client) DeleteMTEConfig(
 ) error {
 	httpRes, err := c.initiateRequest(
 		http.MethodDelete,
-		fmt.Sprintf("/v1/environment/%s/mte/altitude-config", input.EnvironmentId),
+		fmt.Sprintf("/v2/environment/%s/mte/altitude-config", input.EnvironmentId),
 		nil)
 
 	if err != nil {

--- a/internal/provider/client/mte_config_dto.go
+++ b/internal/provider/client/mte_config_dto.go
@@ -21,8 +21,8 @@ type RoutesDto struct {
 }
 
 type CacheDto struct {
-	Keys      *CacheKeyDto `json:"keys,omitempty"`
-	TtlSeconds *int64      `json:"ttlSeconds,omitempty"`
+	Keys       *CacheKeyDto `json:"keys,omitempty"`
+	TtlSeconds *int64       `json:"ttlSeconds,omitempty"`
 	PathRules  *MatcherDto  `json:"pathRules,omitempty"`
 }
 

--- a/internal/provider/client/mte_config_dto.go
+++ b/internal/provider/client/mte_config_dto.go
@@ -3,6 +3,7 @@ package client
 type MTEConfigDto struct {
 	Routes    []RoutesDto   `json:"routes"`
 	BasicAuth *BasicAuthDto `json:"basicAuth,omitempty"`
+	Cache     []CacheDto    `json:"cache,omitempty"`
 }
 
 type BasicAuthDto struct {
@@ -15,10 +16,19 @@ type RoutesDto struct {
 	Path               string         `json:"path"`
 	EnableSsl          bool           `json:"enableSsl"`
 	PreservePathPrefix bool           `json:"preservePathPrefix"`
-	CacheKey           *CacheKeyDto   `json:"cacheKey,omitempty"`
 	AppendPathPrefix   string         `json:"appendPathPrefix,omitempty"`
 	ShieldLocation     ShieldLocation `json:"shieldLocation,omitempty"`
-	CacheMaxAge        *int64         `json:"cacheMaxAge,omitempty"`
+}
+
+type CacheDto struct {
+	Keys      *CacheKeyDto `json:"keys,omitempty"`
+	TtlSeconds *int64      `json:"ttlSeconds,omitempty"`
+	PathRules  *MatcherDto  `json:"pathRules,omitempty"`
+}
+
+type MatcherDto struct {
+	AnyMatch  []string `json:"anyMatch,omitempty"`
+	NoneMatch []string `json:"noneMatch,omitempty"`
 }
 
 type CacheKeyDto struct {

--- a/internal/provider/client/mte_config_dto.go
+++ b/internal/provider/client/mte_config_dto.go
@@ -1,7 +1,7 @@
 package client
 
 type MTEConfigDto struct {
-	Routes    []RoutesDto   `json:"routes"`
+	Routes    []RouteDto    `json:"routes"`
 	BasicAuth *BasicAuthDto `json:"basicAuth,omitempty"`
 	Cache     []CacheDto    `json:"cache,omitempty"`
 }
@@ -11,7 +11,7 @@ type BasicAuthDto struct {
 	Password string `json:"password"`
 }
 
-type RoutesDto struct {
+type RouteDto struct {
 	Host               string         `json:"host"`
 	Path               string         `json:"path"`
 	EnableSsl          bool           `json:"enableSsl"`

--- a/internal/provider/client/mte_config_read.go
+++ b/internal/provider/client/mte_config_read.go
@@ -16,7 +16,7 @@ func (c *Client) ReadMTEConfig(
 ) (*MTEConfigDto, error) {
 	httpRes, err := c.initiateRequest(
 		http.MethodGet,
-		fmt.Sprintf("/v1/environment/%s/mte/altitude-config", input.EnvironmentId),
+		fmt.Sprintf("/v2/environment/%s/mte/altitude-config", input.EnvironmentId),
 		nil)
 
 	if err != nil {

--- a/internal/provider/client/mte_config_update.go
+++ b/internal/provider/client/mte_config_update.go
@@ -26,7 +26,7 @@ func (c *Client) UpdateMTEConfig(
 
 	httpRes, err := c.initiateRequest(
 		http.MethodPut,
-		fmt.Sprintf("/v1/environment/%s/mte/altitude-config", input.EnvironmentId),
+		fmt.Sprintf("/v2/environment/%s/mte/altitude-config", input.EnvironmentId),
 		bytes.NewBuffer(jsonBody))
 
 	if err != nil {

--- a/internal/provider/config_resource.go
+++ b/internal/provider/config_resource.go
@@ -128,15 +128,6 @@ func (m *MTEConfigResource) ValidateConfig(ctx context.Context, req resource.Val
 					"Expected either `keys` or `ttl_seconds` to be set inside the cache object.",
 				)
 			}
-			if c.PathRules != nil {
-				if c.PathRules.AnyMatch == nil && c.PathRules.NoneMatch == nil {
-					resp.Diagnostics.AddAttributeError(
-						path.Root("cache.path_rules"),
-						"Missing Attribute Configuration",
-						"Expected either any_match or none_match to be set in the path rules.",
-					)
-				}
-			}
 		}
 	}
 }
@@ -226,12 +217,12 @@ func (m *MTEConfigResource) Schema(ctx context.Context, req resource.SchemaReque
 									Attributes: map[string]schema.Attribute{
 										"any_match": schema.ListAttribute{
 											ElementType:         types.StringType,
-											Optional:            true,
+											Required:            true,
 											MarkdownDescription: "A list of glob paths where one of the list needs to match for the cache settings to be activated for a path. If both this field and `none_match` are specified, both need to be successful for the path to match.",
 										},
 										"none_match": schema.ListAttribute{
 											ElementType:         types.StringType,
-											Optional:            true,
+											Required:            true,
 											MarkdownDescription: "A list of glob paths where all of the list needs to not match the path for the cache settings to be activated. If both this field and `any_match` are specified, both need to be successful for the path to match.",
 										},
 									},
@@ -491,7 +482,9 @@ func transformToResourceModel(d *client.MTEConfigDto) MTEConfigModel {
 		var cacheModels = make([]CacheModel, len(d.Cache))
 		for i, c := range d.Cache {
 			var cacheModel = CacheModel{}
-			cacheModel.TtlSeconds = types.Int64Value(*c.TtlSeconds)
+			if c.TtlSeconds != nil {
+				cacheModel.TtlSeconds = types.Int64Value(*c.TtlSeconds)
+			}
 			if c.Keys != nil {
 				var cacheKeyHeaders = make([]types.String, len(c.Keys.Header))
 				var cacheKeyCookies = make([]types.String, len(c.Keys.Cookie))

--- a/internal/provider/testdata/altitude_mte_config_basic_auth_excluded.tf
+++ b/internal/provider/testdata/altitude_mte_config_basic_auth_excluded.tf
@@ -1,0 +1,21 @@
+resource "altitude_mte_config" "basic-auth-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+  }
+  environment_id = "%s"
+}

--- a/internal/provider/testdata/altitude_mte_config_basic_auth_included.tf
+++ b/internal/provider/testdata/altitude_mte_config_basic_auth_included.tf
@@ -1,0 +1,25 @@
+resource "altitude_mte_config" "basic-auth-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+    basic_auth = {
+      username = "foobar",
+      password = "barfoo"
+    }
+  }
+  environment_id = "%s"
+}

--- a/internal/provider/testdata/altitude_mte_config_cache_excluded.tf
+++ b/internal/provider/testdata/altitude_mte_config_cache_excluded.tf
@@ -1,0 +1,25 @@
+resource "altitude_mte_config" "cache-field-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+    basic_auth = {
+      username = "foobar",
+      password = "barfoo"
+    }
+  }
+  environment_id = "%s"
+}

--- a/internal/provider/testdata/altitude_mte_config_cache_full.tf
+++ b/internal/provider/testdata/altitude_mte_config_cache_full.tf
@@ -1,0 +1,38 @@
+resource "altitude_mte_config" "cache-field-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+    basic_auth = {
+      username = "foobar",
+      password = "barfoo"
+    }
+    cache = [
+      {
+        path_rules = {
+          any_match = ["/test**"]
+          none_match = ["/test/foo**"]
+        }
+        keys = {
+          headers = ["foo"]
+          cookies = ["bar"]
+        }
+        ttl_seconds = 100
+      }
+    ]
+  }
+  environment_id = "%s"
+}

--- a/internal/provider/testdata/altitude_mte_config_cache_global.tf
+++ b/internal/provider/testdata/altitude_mte_config_cache_global.tf
@@ -1,0 +1,34 @@
+resource "altitude_mte_config" "cache-field-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+    basic_auth = {
+      username = "foobar",
+      password = "barfoo"
+    }
+    cache = [
+      {
+        keys = {
+          headers = ["foo"]
+          cookies = ["bar"]
+        }
+        ttl_seconds = 100
+      }
+    ]
+  }
+  environment_id = "%s"
+}

--- a/internal/provider/testdata/altitude_mte_config_cache_key.tf
+++ b/internal/provider/testdata/altitude_mte_config_cache_key.tf
@@ -1,0 +1,37 @@
+resource "altitude_mte_config" "cache-field-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+    basic_auth = {
+      username = "foobar",
+      password = "barfoo"
+    }
+    cache = [
+      {
+        path_rules = {
+          any_match = ["/test**"]
+          none_match = ["/test/foo**"]
+        }
+        keys = {
+          headers = ["foo"]
+          cookies = ["bar"]
+        }
+      }
+    ]
+  }
+  environment_id = "%s"
+}

--- a/internal/provider/testdata/altitude_mte_config_cache_max_age.tf
+++ b/internal/provider/testdata/altitude_mte_config_cache_max_age.tf
@@ -1,0 +1,34 @@
+resource "altitude_mte_config" "cache-field-test" {
+  config = {
+    routes = [
+      {
+        host                 = "%s"
+        path                 = "/test"
+        enable_ssl           = true
+        preserve_path_prefix = true
+        shield_location      = "London"
+      },
+      {
+        host                 = "docs.thgaltitude.com"
+        path                 = "/docs"
+        enable_ssl           = false
+        preserve_path_prefix = false
+        append_path_prefix   = "foo"
+      }
+    ]
+    basic_auth = {
+      username = "foobar",
+      password = "barfoo"
+    }
+    cache = [
+      {
+        path_rules = {
+          any_match = ["/test**"]
+          none_match = ["/test/foo**"]
+        }
+        ttl_seconds = 100
+      }
+    ]
+  }
+  environment_id = "%s"
+}


### PR DESCRIPTION
## Changes:

- Moving to the v2 API endpoints
- Changing the tests to use static files so it's easier to read
- Adding the global cache key capability